### PR TITLE
Enhance drawing for the vector layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kaibu is a web application for visualizing and annotating multi-dimensional imag
 ----
 ***WARNING: This is a work-in-progress repo, you are welcome to try it out but it's not ready for use in production yet.***
 
-## How to use it
+## How to use it?
 
 ### As standalone appliction: https://kaibu.org
 
@@ -15,24 +15,34 @@ Kaibu is a web application for visualizing and annotating multi-dimensional imag
 ### As ImJoy plugin: https://imjoy.io/#/app?plugin=https://kaibu.org
 
 ```python
+from imjoy import api
 import numpy as np
 
-image1 = np.random.randint(30, 255, [50,100], dtype='uint8')
-image2 = np.random.randint(0, 180, [100,50], dtype='uint8')
+class ImJoyPlugin():
+    async def setup(self):
+        pass
 
-# define two layers
-layers = [
-    {"name": "test image 1", "image": image1, "type": "itk-vtk"},
-    {"name": "test image 2", "image": image2, "type": "itk-vtk"}
-]
+    async def run(self, ctx):
+        viewer = await api.createWindow(src="http://127.0.0.1:8080/")
 
-# show the layers with Kaibu
-api.createWindow(type="Kaibu",
-                 src="https://kaibu.org/", 
-                 data={"layers": layers})
+        # create an random image
+        image = np.random.randint(0, 255, [500,500], dtype='uint8')
+        # view image
+        await viewer.view_image(image)
+        
+        # add polygons
+        points = np.random.randint(0, 500, [100, 2], dtype='uint16').tolist()
+        await viewer.add_shapes(points, shape_type="point")
+
+api.export(ImJoyPlugin())
 ```
 
 You can also try the above code in a Jupyter notebook on binder, [click here](https://mybinder.org/v2/gh/imjoy-team/imjoy-binder-image/master?filepath=imjoy-jupyter-tutorial.ipynb) to launch a notebook on Binder (may take a while to start).
+
+### In a Jupyter notebook
+Run `pip install imjoy-jupyter-extension`, then start the the Jupyter notebook. Then you can use the above plugin example in the notebook.
+
+You can also try the demo here: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/oeway/690c2e62311223ae93e644d542eb8949/master?filepath=Kaibu-jupyter-example.ipynb)
 
 ## Why Kaibu?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12319,6 +12319,11 @@
           "dev": true
         }
       }
+    },
+    "vue-swatches": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vue-swatches/-/vue-swatches-2.1.0.tgz",
+      "integrity": "sha512-JbSomg1penZvgHL24blA3PDgji7LPVGGSFlMo7F+jYVcxooemadI3gkMwFJVIPMikG5g160Mq+Lbph/lqFjzzw=="
     },
     "vue-template-compiler": {
       "version": "2.6.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -18,6 +18,7 @@
     "sortablejs": "^1.10.2",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",
+    "vue-swatches": "^2.1.0",
     "vuex": "^3.4.0"
   },
   "devDependencies": {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -415,7 +415,7 @@ export default {
 
         this.addLayer({
           type: "vector",
-          name: "example shape",
+          name: "shape vectors",
           data: [
             [
               [17.3, 149.3],

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -416,16 +416,8 @@ export default {
         this.addLayer({
           type: "vector",
           name: "shape vectors",
-          data: [
-            [
-              [17.3, 149.3],
-              [17.5, 400],
-              [800, 400],
-              [800, 150]
-            ]
-          ],
-          shape_type: "polygon",
-          edge_color: "#7957d5"
+          data:
+            "https://gist.githubusercontent.com/oeway/7c62128939a7f9b1701e2bbd72b809dc/raw/example_shape_vectors.json"
         });
       }
     }

--- a/src/components/layers/VectorLayer.vue
+++ b/src/components/layers/VectorLayer.vue
@@ -290,7 +290,7 @@ export default {
       size: 7,
       // custom fields
       draw_enable: false,
-      draw_freehand: false,
+      draw_freehand: true,
       draw_label: null,
       draw_size: 7,
       draw_shape_type: "Polygon",

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -56,7 +56,7 @@ export async function setupImJoyAPI({ addLayer }) {
       config = config || {};
       config.type = "vector";
       config.data = point_array;
-      config.shape_type = "Point";
+      config.shape_type = "MultiPoint";
       const layer = await addLayer(config);
       return layer.getLayerAPI();
     }

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -40,6 +40,7 @@ export async function setupImJoyAPI({ addLayer }) {
     async view_image(image_array, config) {
       config = config || {};
       config.type = config.type || "2d-image";
+      config.name = config.name || config.type;
       config.data = image_array;
       const layer = await addLayer(config);
       return layer.getLayerAPI();
@@ -54,7 +55,7 @@ export async function setupImJoyAPI({ addLayer }) {
     async add_points(point_array, config) {
       config = config || {};
       config.type = "vector";
-      config.data = [point_array];
+      config.data = point_array;
       config.shape_type = "Point";
       const layer = await addLayer(config);
       return layer.getLayerAPI();

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,11 @@
 module.exports = {
-  publicPath: process.env.NODE_ENV === 'production'
-  ? '/'
-  : '/',
+  publicPath: '/',
+  pwa: {
+    workboxPluginMode: 'GenerateSW',
+      workboxOptions: {
+          skipWaiting: true
+      }
+  },
   configureWebpack: () => {
 
   }


### PR DESCRIPTION
This PR greatly enhance the vector layer:
 * enhanced drawing UI with icons:
<img width="288" alt="Screenshot 2020-06-11 at 01 55 26" src="https://user-images.githubusercontent.com/478667/84330086-be9aba00-ab86-11ea-9950-684c08ca5431.png">

 * support cursor, select and modify featurs
 * support freehand drawing
 * support setting edge color, face color, edge with, point size
 * support Ctrl+Z undo
 * support moving shape with arrow keys, Shift for fast moving, Ctrl/Cmd for slow moving
 * support import, export geojson file and clear the layer
 * dynamically scale the point shape size
 * add example geojson vector

 * fix points display, tested with  up to 1 million points

```python
points = np.random.randint(0, 500, [100, 2], dtype='uint16').tolist()
await viewer.add_shapes(points, shape_type="point")
```
