### PR TITLE
Support custom UI and support preset visible

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -86,6 +86,25 @@
               </b-dropdown>
             </div>
           </div>
+          <div v-if="customUI" class="block floating-buttons">
+            <b-menu-list :label="customUI.title || ''">
+              <b-tooltip
+                v-for="elm in customUI.elements"
+                :key="elm.label"
+                :label="elm.tooltip || elm.label"
+                position="is-bottom"
+              >
+                <button
+                  v-if="elm.type === 'button'"
+                  @click="elm.callback()"
+                  class="button"
+                >
+                  <b-icon v-if="elm.icon" :icon="elm.icon"> </b-icon
+                  >{{ elm.label }}
+                </button>
+              </b-tooltip>
+            </b-menu-list>
+          </div>
           <b-menu
             class="is-custom-mobile"
             @sorted="layerSorted()"
@@ -296,7 +315,8 @@ export default {
       showGallery: false,
       newLayerType: null,
       collections: null,
-      layerTypes: layerTypes
+      layerTypes: layerTypes,
+      customUI: null
     };
   },
   mounted() {
@@ -466,7 +486,10 @@ export default {
       this.$store.commit("setMap", map);
       // inside an iframe
       if (window.self !== window.top) {
-        setupImJoyAPI({ addLayer: this.addLayer });
+        setupImJoyAPI({
+          addLayer: this.addLayer,
+          setUI: this.setUI
+        });
       } else {
         this.addLayer({
           type: "itk-vtk",
@@ -481,6 +504,9 @@ export default {
             "https://gist.githubusercontent.com/oeway/7c62128939a7f9b1701e2bbd72b809dc/raw/example_shape_vectors.json"
         });
       }
+    },
+    setUI(config) {
+      this.customUI = config;
     },
     screenshot() {
       // TODO: fix rendering for itk-vtk layer

--- a/src/components/layers/ImageLayer.vue
+++ b/src/components/layers/ImageLayer.vue
@@ -180,7 +180,7 @@ export default {
   created() {},
   methods: {
     async init() {
-      this.layer = await this.getLayer();
+      this.layer = await this.setupLayer();
       this.map.addLayer(this.layer);
       this.$forceUpdate();
       return this.layer;
@@ -189,7 +189,7 @@ export default {
       if (this.layer) this.layer.setOpacity(this.config.opacity);
     },
     selectLayer() {},
-    async getLayer() {
+    async setupLayer() {
       let imgObj;
       const data = this.config.data;
       if (typeof data === "string") {

--- a/src/components/layers/ItkVtkLayer.vue
+++ b/src/components/layers/ItkVtkLayer.vue
@@ -187,7 +187,7 @@ export default {
   created() {},
   methods: {
     async init() {
-      this.layer = await this.getLayer();
+      this.layer = await this.setupLayer();
       this.map.addLayer(this.layer);
       this.$forceUpdate();
       return this.layer;
@@ -196,7 +196,7 @@ export default {
       if (this.layer) this.layer.setOpacity(this.config.opacity);
     },
     selectLayer() {},
-    async getLayer() {
+    async setupLayer() {
       const containerStyle = {
         position: "absolute",
         width: "100vw",

--- a/src/components/layers/VectorLayer.vue
+++ b/src/components/layers/VectorLayer.vue
@@ -344,7 +344,7 @@ export default {
   created() {},
   methods: {
     async init() {
-      this.layer = await this.getLayer();
+      this.layer = await this.setupLayer();
       this.map.addLayer(this.layer);
       this.updateDrawInteraction();
       this.$forceUpdate();
@@ -450,7 +450,7 @@ export default {
       const format = new GeoJSON();
       return format.readFeatures(geojson_data);
     },
-    async getLayer() {
+    async setupLayer() {
       const data = this.config.data;
       if (typeof data === "string") {
         this.vector_source = new Vector({

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -21,7 +21,7 @@ function toArray(data) {
   return reshape(Array.from(new arraytype(data._rvalue)), data._rshape);
 }
 
-export async function setupImJoyAPI({ addLayer }) {
+export async function setupImJoyAPI({ addLayer, setUI }) {
   const imjoyRPC = await window.imjoyLoader.loadImJoyRPC({
     api_version: "0.2.3"
   });
@@ -75,6 +75,9 @@ export async function setupImJoyAPI({ addLayer }) {
       config.shape_type = "MultiPoint";
       const layer = await addLayer(config);
       return layer.getLayerAPI();
+    },
+    async set_ui(config) {
+      await setUI(config);
     }
   };
 

--- a/src/store.js
+++ b/src/store.js
@@ -18,6 +18,7 @@ export const store = new Vuex.Store({
           config.init().then(layer => {
             if (!layer) debugger;
             layer.config = config;
+            layer.setVisible(config.visible);
             layer.getLayerAPI = layer.getLayerAPI || function() {};
             context.commit("initialized", layer);
             context.commit("setCurrentLayer", layer.config);


### PR DESCRIPTION
This PR adds support to custom UI, only support buttons for now
```python
        def done():
            api.alert('Done!')
        
        await viewer.set_ui({"elements": [{"type": "button", "label": "OK", "callback": done}]})
```

Another example, for example if we want to add a button to show the geojson features:
```python
        points = np.random.randint(0, 500, [1000, 2], dtype='uint16')
        layer = await viewer.add_points(points, size=4, edge_color="red", draw_enable=True, draw_shape_type="Rectangle", draw_edge_color="yellow")
        
        async def get_geojson_features():
            features = await layer.get_features()
            api.alert(str(features))
        
        await viewer.set_ui({"title": "Utilities", "elements": [{"type": "button", "label": "Show GeoJSON", "callback": get_geojson_features}]})

```

And you can now pass `visible` to `view_image` and `add_shapes`, `add_points`.

@muellerflorian 