### PR TITLE
Add initial support for remote rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7342,8 +7342,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -13,6 +13,7 @@
   "dependencies": {
     "buefy": "^0.8.0",
     "core-js": "^3.6.5",
+    "json-stringify-safe": "^5.0.1",
     "mathjs": "^7.0.1",
     "ol": "^6.3.1",
     "register-service-worker": "^1.7.1",

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -30,14 +30,15 @@
             </div> -->
             <div class="field">
               <b-dropdown aria-role="list">
-                <button
-                  class="button is-primary"
+                <b-button
+                  class="is-primary"
                   slot="trigger"
                   slot-scope="{ active }"
+                  icon-left="layers-plus"
                 >
                   <span>+ Add layer</span>
                   <b-icon :icon="active ? 'menu-up' : 'menu-down'"></b-icon>
-                </button>
+                </b-button>
                 <input
                   ref="file_input"
                   @change="loadFiles($event)"
@@ -55,7 +56,8 @@
 
                 <b-dropdown-item
                   @click="newLayer(type)"
-                  v-for="(name, type) in layerTypes"
+                  v-for="(comp, type) in layerTypes"
+                  v-show="comp.show"
                   :key="type"
                   :value="type"
                   aria-role="listitem"
@@ -221,7 +223,7 @@ const components = {};
 const layerTypes = {};
 for (let c in layerComponents) {
   components[layerComponents[c].name] = layerComponents[c];
-  layerTypes[layerComponents[c].type] = layerComponents[c].name;
+  layerTypes[layerComponents[c].type] = layerComponents[c];
 }
 
 components["gallery"] = Gallery;
@@ -421,6 +423,10 @@ export default {
     },
     toggleVisible(layer) {
       this.$store.commit("toggleVisible", layer);
+      this.$nextTick(() => {
+        this.map.renderSync();
+      });
+
       this.$forceUpdate();
     },
     selectLayer(layer) {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -34,9 +34,9 @@
                   class="is-primary"
                   slot="trigger"
                   slot-scope="{ active }"
-                  icon-left="layers-plus"
+                  icon-left="plus"
                 >
-                  <span>+ Add layer</span>
+                  <span>Add layer</span>
                   <b-icon :icon="active ? 'menu-up' : 'menu-down'"></b-icon>
                 </b-button>
                 <input
@@ -293,6 +293,7 @@ function debounce(func, wait, immediate) {
     if (callNow) func.apply(context, args);
   };
 }
+
 function is_touch_device() {
   return "ontouchstart" in window;
 }

--- a/src/components/layers/ImageLayer.vue
+++ b/src/components/layers/ImageLayer.vue
@@ -115,6 +115,7 @@ function array2rgba(imageArr, ch, w, h) {
 export default {
   name: "image-layer",
   type: "2d-image",
+  show: false,
   props: {
     map: {
       type: Map,

--- a/src/components/layers/ItkVtkLayer.vue
+++ b/src/components/layers/ItkVtkLayer.vue
@@ -41,13 +41,15 @@ import Layer from "ol/layer/Layer";
 
 const itkVtkViewer = window.itkVtkViewer;
 
-var CanvasLayer = /*@__PURE__*/ (function(Layer) {
+const CanvasLayer = /*@__PURE__*/ (function(Layer) {
   function CanvasLayer(options) {
     options = options || {};
     Layer.call(this, options);
     this.viewerElement = document.createElement("div");
     this.viewerElement.classList.add("ol-layer");
     this.viewerElement.style.position = "absolute";
+    this.viewerElement.style.width = "100%";
+    this.viewerElement.style.height = "100%";
     this.sync_callback = options.sync_callback;
   }
 
@@ -64,7 +66,6 @@ var CanvasLayer = /*@__PURE__*/ (function(Layer) {
       this.sync_callback();
     }
     this.viewerElement.style.opacity = this.getOpacity();
-    this.viewerElement.style.width = "100%";
     return this.viewerElement; //return the viewer element
   };
 

--- a/src/components/layers/ItkVtkLayer.vue
+++ b/src/components/layers/ItkVtkLayer.vue
@@ -129,6 +129,7 @@ function generateData3D() {
 export default {
   name: "itk-vtk-layer",
   type: "itk-vtk",
+  show: true,
   props: {
     map: {
       type: Map,

--- a/src/components/layers/RemoteLayer.vue
+++ b/src/components/layers/RemoteLayer.vue
@@ -50,7 +50,6 @@ const CanvasLayer = /*@__PURE__*/ (function(Layer) {
   };
 
   CanvasLayer.prototype.render = function render(frameState) {
-    debugger;
     this.viewerElement.style.opacity = this.getOpacity();
     if (!this._rendering) {
       this._rendering = true;

--- a/src/components/layers/RemoteLayer.vue
+++ b/src/components/layers/RemoteLayer.vue
@@ -1,0 +1,195 @@
+<!-- taken from https://vuejsexamples.com/responsive-image-content-comparison-slider-built-with-vue/ -->
+<template>
+  <div class="itk-vtk-layer">
+    <section
+      :id="'itk-vtk-control_' + config.id"
+      style="position: relative;"
+    ></section>
+    <b-field label="opacity">
+      <b-slider
+        v-model="config.opacity"
+        @input="updateOpacity"
+        :min="0"
+        :max="1.0"
+        :step="0.1"
+      ></b-slider>
+    </b-field>
+  </div>
+</template>
+
+<script>
+import { Map } from "ol";
+import Layer from "ol/layer/Layer";
+import stringify from "json-stringify-safe";
+
+const CanvasLayer = /*@__PURE__*/ (function(Layer) {
+  function CanvasLayer(options) {
+    options = options || {};
+    Layer.call(this, options);
+    this.viewerElement = document.createElement("div");
+    this.viewerElement.classList.add("ol-layer");
+    this.viewerElement.style.position = "absolute";
+    this.viewerElement.style.width = "100%";
+    this.viewerElement.style.height = "100%";
+    const canvas = document.createElement("canvas");
+    canvas.style.position = "absolute";
+    canvas.style.left = "0";
+    this.viewerElement.appendChild(canvas);
+    this.canvasElement = canvas;
+
+    if (!options.renderFunction) throw "render function is not specified";
+    this._renderFunction = options.renderFunction;
+  }
+
+  if (Layer) CanvasLayer.__proto__ = Layer;
+  CanvasLayer.prototype = Object.create(Layer && Layer.prototype);
+  CanvasLayer.prototype.constructor = CanvasLayer;
+
+  CanvasLayer.prototype.getSourceState = function getSourceState() {
+    return "ready";
+  };
+
+  CanvasLayer.prototype.render = function render(frameState) {
+    debugger;
+    this.viewerElement.style.opacity = this.getOpacity();
+    if (!this._rendering) {
+      this._rendering = true;
+      this._renderFunction(
+        JSON.parse(
+          stringify({
+            extent: frameState.extent,
+            index: frameState.index,
+            layerIndex: frameState.layerIndex,
+            pixelRatio: frameState.pixelRatio,
+            coordinateToPixelTransform: frameState.coordinateToPixelTransform,
+            pixelToCorrdinateTransform: frameState.pixelToCorrdinateTransform,
+            size: frameState.size,
+            time: frameState.time,
+            viewState: {
+              center: frameState.viewState.center,
+              resolution: frameState.viewState.resolution,
+              rotation: frameState.viewState.rotation,
+              zoom: frameState.viewState.zoom
+            }
+          })
+        )
+      )
+        .then(workerState => {
+          const canvas = this.canvasElement;
+          // Worker provies a new render frame
+          requestAnimationFrame(() => {
+            const img = new Image();
+            img.onload = function() {
+              canvas.width = img.width;
+              canvas.height = img.height;
+              const ctx = canvas.getContext("2d");
+              ctx.drawImage(img, 0, 0);
+            };
+            const blob = new Blob([workerState.data], {
+              type: workerState.mime
+            });
+            img.src = URL.createObjectURL(blob);
+            if (workerState.transform)
+              canvas.style.transform = workerState.transform;
+          });
+          this._rendering = false;
+        })
+        .catch(e => {
+          console.error(e);
+        });
+    } else {
+      frameState.animate = true;
+    }
+    return this.viewerElement;
+  };
+
+  return CanvasLayer;
+})(Layer);
+
+export default {
+  name: "remote-layer",
+  type: "remote",
+  props: {
+    map: {
+      type: Map,
+      default: null
+    },
+    selected: {
+      type: Boolean,
+      default: false
+    },
+    visible: {
+      type: Boolean,
+      default: false
+    },
+    config: {
+      type: Object,
+      default: function() {
+        return {};
+      }
+    }
+  },
+  data() {
+    return {
+      layer: null,
+      mode: "2D"
+    };
+  },
+  watch: {
+    visible: function(newVal) {
+      this.layer.setVisible(newVal);
+      this.renderWindow.render();
+    }
+  },
+  mounted() {
+    this.config.name = this.config.name || "remote";
+    this.config.opacity = 1.0;
+    this.config.init = this.init;
+  },
+  beforeDestroy() {
+    if (this.layer) {
+      this.map.removeLayer(this.layer);
+    }
+  },
+  created() {},
+  methods: {
+    async init() {
+      this.layer = await this.setupLayer();
+      this.map.addLayer(this.layer);
+      this.$forceUpdate();
+      return this.layer;
+    },
+    updateOpacity() {
+      if (this.layer) this.layer.setOpacity(this.config.opacity);
+    },
+    selectLayer() {},
+    async setupLayer() {
+      return new CanvasLayer({ renderFunction: this.config.render });
+    }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+.itk-vtk-layer > section > div > div > div > canvas {
+  max-width: 100%;
+  height: 140px;
+}
+.itk-vtk-layer > section > div {
+  background: #dedddf;
+}
+.itk-vtk-layer > section > div:first-child {
+  display: none;
+}
+.selected-box {
+  width: 100% !important;
+}
+.selected-icon {
+  width: 100% !important;
+}
+.icon-select .box {
+  left: unset !important;
+  top: 24px !important;
+}
+</style>

--- a/src/components/layers/RemoteLayer.vue
+++ b/src/components/layers/RemoteLayer.vue
@@ -109,6 +109,7 @@ const CanvasLayer = /*@__PURE__*/ (function(Layer) {
 export default {
   name: "remote-layer",
   type: "remote",
+  show: false,
   props: {
     map: {
       type: Map,

--- a/src/components/layers/VectorLayer.vue
+++ b/src/components/layers/VectorLayer.vue
@@ -217,6 +217,7 @@ function saveFile(blob, filename) {
 export default {
   name: "vector-layer",
   type: "vector",
+  show: true,
   components: { VSwatches },
   props: {
     map: {
@@ -253,7 +254,7 @@ export default {
         Square: "vector-square",
         Circle: "vector-circle-variant",
         Star: "octagram-outline",
-        Point: "plus-circle-outline"
+        Point: "target"
       }
     };
   },

--- a/src/components/layers/VectorLayer.vue
+++ b/src/components/layers/VectorLayer.vue
@@ -753,7 +753,6 @@ export default {
           feature.set("edge_color", this.config.draw_edge_color);
           feature.set("edge_width", this.config.draw_edge_width);
           feature.set("face_color", this.config.draw_face_color);
-          console.log(this.config);
         });
         this.draw = draw;
       });

--- a/src/components/layers/index.js
+++ b/src/components/layers/index.js
@@ -1,3 +1,4 @@
 export { default as VectorLayer } from "./VectorLayer.vue";
 export { default as ImageLayer } from "./ImageLayer.vue";
 export { default as ItkVtkLayer } from "./ItkVtkLayer.vue";
+export { default as RemoteLayer } from "./RemoteLayer.vue";


### PR DESCRIPTION

```python
from imjoy import api
import numpy as np
import io
from imageio import imwrite

def render(frameState):
    image = np.random.randint(0, 255, [500,500], dtype='uint8')
    in_mem_file = io.BytesIO()
    imwrite(in_mem_file, image, format="PNG")
    in_mem_file.seek(0)
    img_bytes = in_mem_file.read()
    return {"data": img_bytes, "mime": 'image/png', "transform": "matrix(0.5, 0, 0, 0.5, 0, 0)"}

class ImJoyPlugin():
    async def setup(self):
        pass

    async def run(self, ctx):
        viewer = await api.createWindow(src="http://127.0.0.1:8080")
        viewer.add_layer({"type":"remote", "render":render, "_rintf":True})

api.export(ImJoyPlugin())
```