### PR TITLE
Support UI widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1214,6 +1214,11 @@
       "integrity": "sha512-zeOomWIE52M9JpYXlsR3iOf7TXTTmNQHnSbqjMsQZ5phzfAenHzL/1+vQ0ZoJfagocK11LNf8vnn2JG0ufRMUQ==",
       "dev": true
     },
+    "@types/clone": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.0.tgz",
+      "integrity": "sha512-d/aS/lPOnUSruPhgNtT8jW39fHRVTLQy9sodysP1kkG8EdAtdZu1vt8NJaYA8w/6Z9j8izkAsx1A/yJhcYR1CA=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -1225,6 +1230,11 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
+    },
+    "@types/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ=="
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -2220,6 +2230,11 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
+    },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -3631,8 +3646,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -4315,6 +4329,134 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "d3-array": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+      "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "requires": {
+        "delaunator": "4"
+      }
+    },
+    "d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+    },
+    "d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "requires": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      }
+    },
+    "d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "d3-geo": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.1.tgz",
+      "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+      "requires": {
+        "d3-array": ">=2.5"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
+      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
+      "requires": {
+        "commander": "2",
+        "d3-array": "1 - 2",
+        "d3-geo": "1.12.0 - 2",
+        "resolve": "^1.1.10"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+    },
+    "d3-scale": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+      "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "1 - 2",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "d3-shape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.0.0.tgz",
+      "integrity": "sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==",
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
+      "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "requires": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4619,6 +4761,11 @@
           "dev": true
         }
       }
+    },
+    "delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -4937,8 +5084,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -5046,6 +5192,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -5652,11 +5803,15 @@
         }
       }
     },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6004,8 +6159,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -6548,7 +6702,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -6980,8 +7133,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -7343,6 +7495,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -8580,6 +8737,11 @@
         "semver": "^5.7.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
@@ -9182,8 +9344,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -10518,8 +10679,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -10537,7 +10697,6 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -10651,6 +10810,11 @@
         "aproba": "^1.1.1"
       }
     },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
     "rxjs": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
@@ -10678,8 +10842,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -11425,7 +11588,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11498,7 +11660,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       },
@@ -11506,8 +11667,7 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         }
       }
     },
@@ -11863,6 +12023,14 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
+    },
+    "topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "requires": {
+        "commander": "2"
+      }
     },
     "toposort": {
       "version": "2.0.2",
@@ -12269,6 +12437,482 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
+    "vega": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.17.0.tgz",
+      "integrity": "sha512-2Rm9aS3cSMXE55YgjfkuOmvSBMtiM/85/qX/WHLc+YiJacKGiwY9yzeC+w2Ft50JUs3nKZc1KB90ePgf5mfo0Q==",
+      "requires": {
+        "vega-crossfilter": "~4.0.5",
+        "vega-dataflow": "~5.7.3",
+        "vega-encode": "~4.8.3",
+        "vega-event-selector": "~2.0.6",
+        "vega-expression": "~3.0.0",
+        "vega-force": "~4.0.7",
+        "vega-format": "~1.0.4",
+        "vega-functions": "~5.8.0",
+        "vega-geo": "~4.3.7",
+        "vega-hierarchy": "~4.0.9",
+        "vega-label": "~1.0.0",
+        "vega-loader": "~4.4.0",
+        "vega-parser": "~6.1.0",
+        "vega-projection": "~1.4.5",
+        "vega-regression": "~1.0.9",
+        "vega-runtime": "~6.1.3",
+        "vega-scale": "~7.1.1",
+        "vega-scenegraph": "~4.9.2",
+        "vega-statistics": "~1.7.9",
+        "vega-time": "~2.0.4",
+        "vega-transforms": "~4.9.3",
+        "vega-typings": "~0.19.0",
+        "vega-util": "~1.16.0",
+        "vega-view": "~5.9.0",
+        "vega-view-transforms": "~4.5.8",
+        "vega-voronoi": "~4.1.5",
+        "vega-wordcloud": "~4.1.3"
+      }
+    },
+    "vega-canvas": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.6.tgz",
+      "integrity": "sha512-rgeYUpslYn/amIfnuv3Sw6n4BGns94OjjZNtUc9IDji6b+K8LGS/kW+Lvay8JX/oFqtulBp8RLcHN6QjqPLA9Q=="
+    },
+    "vega-crossfilter": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
+      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-dataflow": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.3.tgz",
+      "integrity": "sha512-2ipzKgQUmbSXcQBH+9XF0BYbXyZrHvjlbJ8ifyRWYQk78w8kMvE6wy/rcdXYK6iVZ6aAbEDDT7jTI+rFt3tGLA==",
+      "requires": {
+        "vega-format": "^1.0.4",
+        "vega-loader": "^4.3.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-embed": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.12.2.tgz",
+      "integrity": "sha512-oYRnadLq9PgKL6I5uVTa4hiEXujv8EYqhy2eb9Afb5GrdHNOHsWOVIyiin0gSYa16hLM/Av0uRcsJdDk8vi9vA==",
+      "requires": {
+        "fast-json-patch": "^3.0.0-1",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "semver": "^7.3.2",
+        "vega-schema-url-parser": "^2.1.0",
+        "vega-themes": "^2.9.0",
+        "vega-tooltip": "^0.24.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
+      }
+    },
+    "vega-encode": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
+      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-event-selector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
+    },
+    "vega-expression": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-3.0.0.tgz",
+      "integrity": "sha512-/ObjIOK94MB+ziTuh8HZt2eWlKUPT/piRJLal5tx5QL1sQbfRi++7lHKTaKMLXLqc4Xqp9/DewE3PqQ6tYzaUA==",
+      "requires": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-force": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
+      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
+      "requires": {
+        "d3-force": "^2.1.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
+      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-format": "^2.0.0",
+        "d3-time-format": "^3.0.0",
+        "vega-time": "^2.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-functions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.8.0.tgz",
+      "integrity": "sha512-xaUqWZHEX+EuJuKfN0Biux3rrCHDEHmMbW7LHYyyEqguR0i6+zhtOSUEWmYqDfzB/+BlIwCk5Vif6q6/mzJxbQ==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-expression": "^3.0.0",
+        "vega-scale": "^7.1.1",
+        "vega-scenegraph": "^4.9.2",
+        "vega-selections": "^5.1.4",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-geo": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.7.tgz",
+      "integrity": "sha512-5HC1D9Z/WYuM1Gmlk8PxuRKgeN8snNWsfKO4E9PTmR7wo7tuU/2SGlRoE27aTsgwMMpBIrpRbSgKtgh5l/fMUQ==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-projection": "^1.4.5",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-hierarchy": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
+      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
+      "requires": {
+        "d3-hierarchy": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-label": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.0.0.tgz",
+      "integrity": "sha512-hCdm2pcHgkKgxnzW9GvX5JmYNiUMlOXOibtMmBzvFBQHX3NiV9giQ5nsPiQiFbV08VxEPtM+VYXr2HyrIcq5zQ==",
+      "requires": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-lite": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-4.17.0.tgz",
+      "integrity": "sha512-MO2XsaVZqx6iWWmVA5vwYFamvhRUsKfVp7n0pNlkZ2/21cuxelSl92EePZ2YGmzL6z4/3K7r/45zaG8p+qNHeg==",
+      "requires": {
+        "@types/clone": "~2.1.0",
+        "@types/fast-json-stable-stringify": "^2.0.0",
+        "array-flat-polyfill": "^1.0.1",
+        "clone": "~2.1.2",
+        "fast-deep-equal": "~3.1.3",
+        "fast-json-stable-stringify": "~2.1.0",
+        "json-stringify-pretty-compact": "~2.0.0",
+        "tslib": "~2.0.3",
+        "vega-event-selector": "~2.0.6",
+        "vega-expression": "~3.0.0",
+        "vega-util": "~1.16.0",
+        "yargs": "~16.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.3.tgz",
+          "integrity": "sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+        },
+        "yargs": {
+          "version": "16.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+          "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+          "requires": {
+            "cliui": "^7.0.0",
+            "escalade": "^3.0.2",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.1",
+            "yargs-parser": "^20.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
+        }
+      }
+    },
+    "vega-loader": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.0.tgz",
+      "integrity": "sha512-e5enQECdau7rJob0NFB5pGumh3RaaSWWm90+boxMy3ay2b4Ki/3XIvo+C4F1Lx04qSxvQF7tO2LJcklRm6nqRA==",
+      "requires": {
+        "d3-dsv": "^2.0.0",
+        "node-fetch": "^2.6.1",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.0.4",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "vega-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.0.tgz",
+      "integrity": "sha512-u14bHXV8vtcuMIJkMNoDAJ4Xu3lwKIkep+YEkPumWvlwl3fClWy26EAcwTneeM3rXu2F6ZJI6W3ddu/If8u13w==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-event-selector": "^2.0.6",
+        "vega-functions": "^5.8.0",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-projection": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
+      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
+      "requires": {
+        "d3-geo": "^2.0.1",
+        "d3-geo-projection": "^3.0.0"
+      }
+    },
+    "vega-regression": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
+      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-runtime": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.3.tgz",
+      "integrity": "sha512-gE+sO2IfxMUpV0RkFeQVnHdmPy3K7LjHakISZgUGsDI/ZFs9y+HhBf8KTGSL5pcZPtQsZh3GBQ0UonqL1mp9PA==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-scale": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
+      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.2",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-scenegraph": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.2.tgz",
+      "integrity": "sha512-epm1CxcB8AucXQlSDeFnmzy0FCj+HV2k9R6ch2lfLRln5lPLEfgJWgFcFhVf5jyheY0FSeHH52Q5zQn1vYI1Ow==",
+      "requires": {
+        "d3-path": "^2.0.0",
+        "d3-shape": "^2.0.0",
+        "vega-canvas": "^1.2.5",
+        "vega-loader": "^4.3.3",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-schema-url-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.1.0.tgz",
+      "integrity": "sha512-JHT1PfOyVzOohj89uNunLPirs05Nf59isPT5gnwIkJph96rRgTIBJE7l7yLqndd7fLjr3P8JXHGAryRp74sCaQ=="
+    },
+    "vega-selections": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.1.4.tgz",
+      "integrity": "sha512-L7CHwcIjVf90GoW2tS2x5O496O5Joaerp5A1KM6VJ1uo4z6KfqxY6M/328a/uaAs0LC5qbQgXT3htFbtUrPW/A==",
+      "requires": {
+        "vega-expression": "^3.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-statistics": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.9.tgz",
+      "integrity": "sha512-T0sd2Z08k/mHxr1Vb4ajLWytPluLFYnsYqyk4SIS5czzUs4errpP2gUu63QJ0B7CKNu33vnS9WdOMOo/Eprr/Q==",
+      "requires": {
+        "d3-array": "^2.7.1"
+      }
+    },
+    "vega-themes": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.9.1.tgz",
+      "integrity": "sha512-N6GU8u1EpfqxswXpBKLYouD3gYGfvrKWTC07JSrnlvGUzKzXMPDm4fN8FP8+cBpTwBL6JDZBd86A1Haea/nTfQ=="
+    },
+    "vega-time": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
+      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-time": "^2.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-tooltip": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.24.2.tgz",
+      "integrity": "sha512-b7IeYQl/piNVsMmTliOgTnwSOhBs67KqoZ9UzP1I3XpH7TKbSuc3YHA7b1CSxkRR0hHKdradby4UI8c9rdH74w==",
+      "requires": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-transforms": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.3.tgz",
+      "integrity": "sha512-PdqQd5oPlRyD405M2w+Sz9Bo+i7Rwi8o03SVK7RaeQsJC2FffKGJ6acIaSEgOq+yD1Q2k/1SePmCXcmLUlIiEA==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-typings": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.19.1.tgz",
+      "integrity": "sha512-OSyNYwMJ8FayTTNU/gohprbt1EFQBpoiMPP9p2vqo1O9z45XVnotQ92jYHAhraI6gWiMIIfo4OjPbSe/GX7etg==",
+      "requires": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-util": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.0.tgz",
+      "integrity": "sha512-6mmz6mI+oU4zDMeKjgvE2Fjz0Oh6zo6WGATcvCfxH2gXBzhBHmy5d25uW5Zjnkc6QBXSWPLV9Xa6SiqMsrsKog=="
+    },
+    "vega-view": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.9.0.tgz",
+      "integrity": "sha512-HqRFuqO2OwoPHHK+CVt8vB8fu2L8GjQerLpmEpglWtCPDns5+gn5B6F7M8Ah8v24WlfqW7cLrY81t9OloPZOyw==",
+      "requires": {
+        "d3-array": "^2.7.1",
+        "d3-timer": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-format": "^1.0.4",
+        "vega-functions": "^5.8.0",
+        "vega-runtime": "^6.1.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-view-transforms": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.8.tgz",
+      "integrity": "sha512-966m7zbzvItBL8rwmF2nKG14rBp7q+3sLCKWeMSUrxoG+M15Smg5gWEGgwTG3A/RwzrZ7rDX5M1sRaAngRH25g==",
+      "requires": {
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-voronoi": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
+      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
+      "requires": {
+        "d3-delaunay": "^5.3.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-wordcloud": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.3.tgz",
+      "integrity": "sha512-is4zYn9FMAyp9T4SAcz2P/U/wqc0Lx3P5YtpWKCbOH02a05vHjUQrQ2TTPOuvmMfAEDCSKvbMSQIJMOE018lJA==",
+      "requires": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.1.1",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
     "vendors": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
@@ -12328,6 +12972,11 @@
           }
         }
       }
+    },
+    "vue-form-generator": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/vue-form-generator/-/vue-form-generator-2.3.4.tgz",
+      "integrity": "sha512-gkGLukX2xyVYASVopRVt/v4ZVFpoH+I1j+yRIkJBOR9++UwZTi8yREWydnKukpp/r90SGX68Yzy4OkQrKZHluQ=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
@@ -22,7 +22,11 @@
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",
     "vue-swatches": "^2.1.0",
-    "vuex": "^3.4.0"
+    "vuex": "^3.4.0",
+    "vega": "^5.7.3",
+    "vega-embed": "^6.0.0",
+    "vega-lite": "^4.12.2",
+    "vue-form-generator": "^2.3.4"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.4.0",

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -88,25 +88,68 @@
               </b-dropdown>
             </div>
           </div>
-          <div v-if="customUI" class="block floating-buttons">
-            <b-menu-list :label="customUI.title || ''">
-              <b-tooltip
-                v-for="elm in customUI.elements"
-                :key="elm.label"
-                :label="elm.tooltip || elm.label"
-                position="is-bottom"
+          <b-tabs size="is-small" class="block">
+            <b-tab-item
+              v-for="(widget, id) in widgets"
+              :key="id"
+              :label="widget.title"
+              :icon="widget.icon"
+            >
+              <div
+                class="block floating-buttons"
+                v-if="!widget.type || widget.type === 'control'"
               >
-                <button
-                  v-if="elm.type === 'button'"
-                  @click="elm.callback()"
-                  class="button"
+                <b-tooltip
+                  v-for="elm in widget.elements"
+                  :key="elm.label"
+                  :label="elm.tooltip || elm.label"
+                  position="is-bottom"
                 >
-                  <b-icon v-if="elm.icon" :icon="elm.icon"> </b-icon
-                  >{{ elm.label }}
-                </button>
-              </b-tooltip>
-            </b-menu-list>
-          </div>
+                  <button
+                    v-if="elm.type === 'button'"
+                    @click="elm.callback()"
+                    class="button is-small"
+                    style="min-width:120px;"
+                  >
+                    <b-icon v-if="elm.icon" :icon="elm.icon"> </b-icon
+                    >{{ elm.label }}
+                  </button>
+                </b-tooltip>
+              </div>
+              <div
+                class="block floating-buttons"
+                v-else-if="widget.type === 'list'"
+              >
+                <b-menu-list>
+                  <b-menu-item
+                    v-for="elm in widget.elements"
+                    :key="elm.label"
+                    @click="widget.select_callback(elm)"
+                  >
+                    <template slot="label">
+                      {{ elm.label }}
+                    </template>
+                  </b-menu-item>
+                </b-menu-list>
+                <b-tooltip
+                  v-for="elm in widget.elements"
+                  :key="elm.label"
+                  :label="elm.tooltip || elm.label"
+                  position="is-bottom"
+                >
+                  <button
+                    v-if="elm.type === 'button'"
+                    @click="elm.callback()"
+                    class="button is-small"
+                    style="min-width:120px;"
+                  >
+                    <b-icon v-if="elm.icon" :icon="elm.icon"> </b-icon
+                    >{{ elm.label }}
+                  </button>
+                </b-tooltip>
+              </div>
+            </b-tab-item>
+          </b-tabs>
           <b-menu
             class="is-custom-mobile"
             @sorted="layerSorted()"
@@ -149,7 +192,6 @@
           </b-menu>
 
           <hr class="solid" />
-
           <div class="block" v-show="currentLayer" style="min-height: 150px;">
             <b-menu-list label="Properties">
               <component
@@ -319,7 +361,7 @@ export default {
       newLayerType: null,
       collections: null,
       layerTypes: layerTypes,
-      customUI: null
+      widgets: {}
     };
   },
   mounted() {
@@ -495,6 +537,7 @@ export default {
           addLayer: this.addLayer,
           removeLayer: this.removeLayer,
           clearLayers: this.clearLayers,
+          addWidget: this.addWidget,
           setUI: this.setUI
         });
       } else {
@@ -512,8 +555,13 @@ export default {
         });
       }
     },
+    addWidget(config) {
+      config.title = config.title || "default";
+      this.widgets[config.title] = config;
+    },
     setUI(config) {
-      this.customUI = config;
+      config.title = config.title || "default";
+      this.widgets[config.title] = config;
     },
     screenshot() {
       // TODO: fix rendering for itk-vtk layer
@@ -623,7 +671,7 @@ export default {
 /* Solid border */
 hr.solid {
   margin-top: 10px;
-  border-top: 2px solid #ccc5c5;
+  border-top: 1px solid #ccc5c553;
   margin-bottom: 15px;
 }
 

--- a/src/components/layers/ImageLayer.vue
+++ b/src/components/layers/ImageLayer.vue
@@ -1,4 +1,3 @@
-<!-- taken from https://vuejsexamples.com/responsive-image-content-comparison-slider-built-with-vue/ -->
 <template>
   <div class="image-layer">
     <section v-if="layer">

--- a/src/components/layers/ItkVtkLayer.vue
+++ b/src/components/layers/ItkVtkLayer.vue
@@ -1,4 +1,3 @@
-<!-- taken from https://vuejsexamples.com/responsive-image-content-comparison-slider-built-with-vue/ -->
 <template>
   <div class="itk-vtk-layer">
     <section>
@@ -287,23 +286,28 @@ export default {
           files = this.config.data;
         } else files = await this.getFiles();
 
-        const cfg = await itkVtkViewer.utils.readFiles({ files: files });
-        cfg.uiContainer = document.getElementById("toolbar");
-        is2D = cfg.use2D;
-        cfg.uiContainer = document.getElementById(
-          "itk-vtk-control_" + this.config.id
-        );
-        viewer = itkVtkViewer.createViewer(itk_layer.viewerElement, cfg);
-        const vs = viewer
-          .getViewProxy()
-          .getRenderer()
-          .getVolumes();
-        if (vs.length > 0) {
-          const extent_3d = vs[0].getBounds();
-          extent = [extent_3d[0], extent_3d[2], extent_3d[1], extent_3d[3]];
-        } else {
-          console.warn("Extent is not set.");
-          extent = [0, 0, 100, 100];
+        try {
+          this.$emit("loading", true);
+          const cfg = await itkVtkViewer.utils.readFiles({ files: files });
+          cfg.uiContainer = document.getElementById("toolbar");
+          is2D = cfg.use2D;
+          cfg.uiContainer = document.getElementById(
+            "itk-vtk-control_" + this.config.id
+          );
+          viewer = itkVtkViewer.createViewer(itk_layer.viewerElement, cfg);
+          const vs = viewer
+            .getViewProxy()
+            .getRenderer()
+            .getVolumes();
+          if (vs.length > 0) {
+            const extent_3d = vs[0].getBounds();
+            extent = [extent_3d[0], extent_3d[2], extent_3d[1], extent_3d[3]];
+          } else {
+            console.warn("Extent is not set.");
+            extent = [0, 0, 100, 100];
+          }
+        } finally {
+          this.$emit("loading", false);
         }
       }
       if (!viewer) throw "Failed to load itk-vtk-viewer";

--- a/src/components/layers/RemoteLayer.vue
+++ b/src/components/layers/RemoteLayer.vue
@@ -1,4 +1,3 @@
-<!-- taken from https://vuejsexamples.com/responsive-image-content-comparison-slider-built-with-vue/ -->
 <template>
   <div class="itk-vtk-layer">
     <section

--- a/src/components/layers/VectorLayer.vue
+++ b/src/components/layers/VectorLayer.vue
@@ -1,4 +1,3 @@
-<!-- taken from https://vuejsexamples.com/responsive-image-content-comparison-slider-built-with-vue/ -->
 <template>
   <div class="vector-layer">
     <section>

--- a/src/components/widgets/ControlWidget.vue
+++ b/src/components/widgets/ControlWidget.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="control-widget block floating-buttons">
+    <b-tooltip
+      v-for="elm in config.elements"
+      :key="elm.label"
+      :label="elm.tooltip || elm.label"
+      position="is-bottom"
+    >
+      <button
+        v-if="elm.type === 'button'"
+        @click="triggerCallback(elm)"
+        class="button is-small"
+        style="min-width:120px;"
+      >
+        <b-icon v-if="elm.icon" :icon="elm.icon"> </b-icon>{{ elm.label }}
+      </button>
+    </b-tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "control-widget",
+  type: "control",
+  props: {
+    config: {
+      type: Object,
+      default: function() {
+        return {};
+      }
+    }
+  },
+  data() {
+    return {};
+  },
+  mounted() {
+    if (this.config._resolve) {
+      this.config._resolve({});
+    }
+  },
+  methods: {
+    async triggerCallback(elm) {
+      try {
+        this.$emit("loading", true);
+        await elm.callback();
+      } finally {
+        this.$emit("loading", false);
+      }
+    }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style></style>

--- a/src/components/widgets/FormWidget.vue
+++ b/src/components/widgets/FormWidget.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="form-widgett"></div>
+</template>
+
+<script>
+export default {
+  name: "form-widget",
+  type: "form",
+  props: {
+    config: {
+      type: Object,
+      default: function() {
+        return {};
+      }
+    }
+  },
+  data() {
+    return {};
+  },
+  mounted() {
+    if (this.config._resolve) {
+      this.config._resolve({});
+    }
+  },
+  methods: {}
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style></style>

--- a/src/components/widgets/ListWidget.vue
+++ b/src/components/widgets/ListWidget.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="list-widget">
+    <b-menu>
+      <b-menu-list>
+        <b-menu-item
+          class="is-small"
+          v-for="elm in config.elements"
+          :key="elm.label"
+          @click="config.select_callback(elm)"
+        >
+          <template slot="label">
+            {{ elm.label }}
+          </template>
+        </b-menu-item>
+      </b-menu-list>
+    </b-menu>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "list-widget",
+  type: "list",
+  props: {
+    config: {
+      type: Object,
+      default: function() {
+        return {};
+      }
+    }
+  },
+  data() {
+    return {};
+  },
+  created() {
+    this.config.select_callback = this.config.select_callback || function() {};
+  },
+  mounted() {
+    if (this.config._resolve) {
+      this.config._resolve({});
+    }
+  },
+  methods: {}
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+.menu-list {
+  font-size: 14px;
+  line-height: 0.9;
+}
+</style>

--- a/src/components/widgets/Vega.vue
+++ b/src/components/widgets/Vega.vue
@@ -1,0 +1,39 @@
+<template>
+  <div></div>
+</template>
+<script>
+import * as vega from "vega";
+import vegaEmbed from "vega-embed";
+
+export default {
+  name: "vega",
+  props: ["schema", "options"],
+  mounted() {
+    vegaEmbed(this.$el, this.schema, this.options || { actions: false }).then(
+      res => {
+        this.embed = res;
+        this.view = res.view;
+        this.$emit("ready", { view: res.view, vega });
+      }
+    );
+  },
+  data: () => {
+    return {
+      view: null,
+      embed: null
+    };
+  },
+  methods: {
+    updateView(dataName, data) {
+      const changeSet = vega.changeset().insert(data);
+      this.view.change(dataName, changeSet).run();
+    }
+    // clearView(dataName){
+    //   const changeSet = vega.changeset().remove(()=>{
+    //     return true
+    //   });
+    //   this.view.change(dataName, changeSet).run();
+    // }
+  }
+};
+</script>

--- a/src/components/widgets/VegaWidget.vue
+++ b/src/components/widgets/VegaWidget.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <p v-if="title" class="vega-title">{{ title }}</p>
+    <vega
+      :schema="config.schema"
+      :options="config.options"
+      @ready="vegaReady"
+      ref="main"
+    ></vega>
+  </div>
+</template>
+
+<script>
+import Vega from "@/components/widgets/Vega";
+
+export default {
+  name: "vega-widget",
+  type: "vega",
+  components: { vega: Vega },
+  props: {
+    config: {
+      type: Object,
+      default: function() {
+        return {};
+      }
+    }
+  },
+  data() {
+    return {
+      title: null
+    };
+  },
+  created() {
+    this.config.options = this.config.options || {};
+    this.config.options.width = this.config.options.width || 200;
+  },
+  mounted() {
+    this.title = this.config.title;
+  },
+  methods: {
+    vegaReady({ view, vega }) {
+      if (this.config.click_callback) {
+        view.addEventListener("click", async (event, item) => {
+          try {
+            this.$emit("loading", true);
+            await this.config.click_callback(item.datum);
+          } finally {
+            this.$emit("loading", false);
+          }
+        });
+      }
+      if (this.config._resolve) {
+        this.config._resolve({
+          _rintf: true,
+          append: this.appendDataPoint,
+          // clear: this.clearData,
+          set_title: this.setTitle,
+          set_expression_function(name, func) {
+            vega.expressionFunction(name, func);
+          }
+        });
+      }
+    },
+    setTitle(title) {
+      this.title = title;
+      this.$forceUpdate();
+    },
+    appendDataPoint(dataName, data) {
+      this.$refs.main.updateView(dataName, data);
+    }
+    // clearData(){
+    //   this.$refs.main.clearView();
+    // }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+.vega-title {
+  text-align: center;
+  font-size: 12px;
+}
+</style>

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -1,0 +1,4 @@
+export { default as ControlWidget } from "./ControlWidget.vue";
+export { default as FormWidget } from "./FormWidget.vue";
+export { default as ListWidget } from "./ListWidget.vue";
+export { default as VegaWidget } from "./VegaWidget.vue";

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -55,8 +55,11 @@ export async function setupImJoyAPI({
   addLayer,
   removeLayer,
   clearLayers,
-  setUI
+  addWidget,
+  setLoader,
+  setMode
 }) {
+  setMode("lite");
   const imjoyRPC = await window.imjoyLoader.loadImJoyRPC({
     api_version: "0.2.3"
   });
@@ -114,7 +117,24 @@ export async function setupImJoyAPI({
       return layer.getLayerAPI();
     },
     async set_ui(config) {
-      await setUI(config);
+      config.type = config.type || "control";
+      config.name = config.title;
+      return await addWidget(config);
+    },
+    async add_widget(config) {
+      return await addWidget(config);
+    },
+    async set_loader(enable) {
+      setLoader(enable);
+    },
+    async set_timeout(func, time) {
+      return setTimeout(func, time);
+    },
+    async clear_timeout(id) {
+      clearTimeout(id);
+    },
+    async set_mode(mode) {
+      setMode(mode);
     }
   };
 


### PR DESCRIPTION
This PR adds support for UI widgets which can be used to display charts, lists etc.

Add a vega based line plot and buttons:
```python
viewer = await api.createWindow(src="https://kaibu.org/#/app")
losses = [{"iteration": 0, "loss": 10.1}, {"iteration": 2, "loss": 3.34}]
chart = await viewer.add_widget(
            {
                "_rintf": True,
                "name": "Training",
                "type": "vega",
                "schema": {
                    "$schema": "https://vega.github.io/schema/vega-lite/v4.8.1.json",
                    "mark": "line",
                    "encoding": {"x": {"type": "quantitative", "field": "iteration"},
                                  "y": {"type": "quantitative", "field": "loss"}
                                 },
                    "data": {"name": "loss"},
                    "datasets": {"loss": losses}
                },
            }
        )

def callback():
     api.alert('button clicked')

await viewer.add_widget(
            {
                "_rintf": True,
                "name": "Control",
                "type": "control",
                "elements": [
                    {
                        "type": "button",
                        "label": "Click Me",
                        "callback": callback
                    },
                 ]
         })

```

