### PR TITLE
Support drop files in the form widget

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -295,6 +295,7 @@ For `type="form"`, you can show a form with many fields for the user to fill.
  - `type`: String, type of the widget panel, it must be `form` for form widget
  - `attach_to`: String or null, if set, it means this widget will be attached to a layer (match by its name) and will be shown with the layer properties
  - `max_height`: Number, the maximum pixel height of the widget, the default value is 400.
+ - `camelize_payload_keys`: Boolean, whether the keys (derived from the `label` property of the field) should be converted too camel style
  - `form_submit_callback`: Function, a callback function which will be called when the user submit the form. It carries one argument which are the values of the form.
  - `fields`: Array, an array of fields, see [here](https://github.com/14nrv/vue-form-json/blob/master/src/components/Form/fields.json) for an example array with the supported fields.
     In addition to the standard fields supported by `vue-form-json`, we also provide custom fields via a different setting (i.e. `slots`):
@@ -318,6 +319,15 @@ For `type="form"`, you can show a form with many fields for the user to fill.
                 // and it will be filled as part of the form
                 return file
             } 
+        }
+    }
+    ```
+    - `dropFiles`:
+    ```js
+    {
+        slot: "dropFiles",
+        props: {
+            label: "my-files"
         }
     }
     ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15950,12 +15950,6 @@
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
       }
-    },
-    "yarn": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.10.tgz",
-      "integrity": "sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==",
-      "dev": true
     },
     "yorkie": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.35",
-  "private": true,
+  "version": "0.1.36",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
@@ -49,8 +48,7 @@
     "prettier": "^1.19.1",
     "vue-cli-plugin-buefy": "~0.3.7",
     "vue-template-compiler": "^2.6.11",
-    "copy-webpack-plugin": "^4.6.0",
-    "yarn": "^1.22.10"
+    "copy-webpack-plugin": "^4.6.0"
   },
   "eslintConfig": {
     "root": true,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -556,6 +556,23 @@ export default {
           only_predefined_tags: true,
           single_tag_mode: false
         });
+
+        await this.addWidget({
+          _rintf: true,
+          name: "My Form",
+          type: "form",
+          form_submit_callback: values => {
+            console.log(values);
+          },
+          fields: [
+            {
+              slot: "dropFiles",
+              props: {
+                label: "my-files"
+              }
+            }
+          ]
+        });
       }
     },
     updateSlider(name, value) {


### PR DESCRIPTION
Add a dropFiles slot for getting files from the user in the form widget.

Breaking change: the default value for the `camelize_payload_keys` option in the `form` widget has been changed to `false`.