### PR TITLE
Support passing ui mode through the config key

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,18 @@ api.export(ImJoyPlugin())
 ```
 <!-- tabs:end -->
 
+By default, if Kaibu is accessed as an ImJoy plugin, the so called `minimal` UI mode will be applied. If you want a full UI options such as allow user to add new layer, you can pass `mode: 'full'` as a config option. For example:
+
+<!-- ImJoyPlugin: {"type": "web-worker", "editor_height": "400px"} -->
+```js
+class ImJoyPlugin {
+    async setup() {}
+    async run(ctx) {
+        const viewer = await api.createWindow({src: "https://kaibu.org/#/app", name: "Kaibu", config: {mode: 'full'}})
+    }
+}
+api.export(new ImJoyPlugin())
+```
 ## Kaibu API
 
 ### view_image(image, options)
@@ -607,7 +619,7 @@ Set the UI mode of the viewer
 **Arguments**
  - `mode`: String, it should be one of the following options:
     - `"lite"`: minimal UI mode
-    - `"full"`: full UI mode
+    - `"full"`: full UI mode, with additional options such as open local files and add new layer etc.
 
 ### set_timeout(callback, time)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaibu",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -85,6 +85,9 @@ export async function setupImJoyAPI({
       api.log("Kaibu loaded successfully.");
     },
     async run(ctx) {
+      if(ctx.config && ctx.config.mode){
+        setMode(ctx.config.mode);
+      }
       if (ctx.data && ctx.data.layers) {
         const layer_apis = [];
         for (let config of ctx.data.layers) {

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -85,7 +85,7 @@ export async function setupImJoyAPI({
       api.log("Kaibu loaded successfully.");
     },
     async run(ctx) {
-      if(ctx.config && ctx.config.mode){
+      if (ctx.config && ctx.config.mode) {
         setMode(ctx.config.mode);
       }
       if (ctx.data && ctx.data.layers) {


### PR DESCRIPTION
This allows passing the UI mode through the `config` key: 

```js
const viewer = await api.createWindow({src: "https://kaibu.org/#/app", name: "Kaibu", config: {mode: 'full' }})
```